### PR TITLE
Add test package

### DIFF
--- a/cmd/command/build.go
+++ b/cmd/command/build.go
@@ -26,17 +26,18 @@ func NewBuild(ui cli.Ui) *Build {
 }
 
 // Synopsis returns the short one-line synopsis of the command.
-func (b *Build) Synopsis() string {
+func (c *Build) Synopsis() string {
 	return buildSynopsis
 }
 
 // Help returns the long help text including usage, description, and list of flags for the command
-func (b *Build) Help() string {
+func (c *Build) Help() string {
 	return buildHelp
 }
 
 // Run runs the actual command with the given CLI instance and command-line arguments
-func (b *Build) Run(args []string) int {
-	b.ui.Output("build command run")
+func (c *Build) Run(args []string) int {
+	c.ui.Output("build command run")
+
 	return 0
 }

--- a/cmd/command/release.go
+++ b/cmd/command/release.go
@@ -26,17 +26,18 @@ func NewRelease(ui cli.Ui) *Release {
 }
 
 // Synopsis returns the short one-line synopsis of the command.
-func (b *Release) Synopsis() string {
+func (c *Release) Synopsis() string {
 	return releaseSynopsis
 }
 
 // Help returns the long help text including usage, description, and list of flags for the command
-func (b *Release) Help() string {
+func (c *Release) Help() string {
 	return releaseHelp
 }
 
 // Run runs the actual command with the given CLI instance and command-line arguments
-func (b *Release) Run(args []string) int {
-	b.ui.Output("release command run")
+func (c *Release) Run(args []string) int {
+	c.ui.Output("release command run")
+
 	return 0
 }

--- a/cmd/command/test.go
+++ b/cmd/command/test.go
@@ -1,7 +1,11 @@
 package command
 
 import (
+	"context"
+	"time"
+
 	"github.com/mitchellh/cli"
+	"github.com/moorara/cherry/internal/test"
 )
 
 const (
@@ -14,29 +18,41 @@ const (
 type (
 	// Test is the test CLI command
 	Test struct {
-		ui cli.Ui
+		ui     cli.Ui
+		tester test.Tester
 	}
 )
 
 // NewTest create a new test command
 func NewTest(ui cli.Ui) *Test {
+	tester := test.NewTester("./")
+
 	return &Test{
-		ui: ui,
+		ui:     ui,
+		tester: tester,
 	}
 }
 
 // Synopsis returns the short one-line synopsis of the command.
-func (b *Test) Synopsis() string {
+func (c *Test) Synopsis() string {
 	return testSynopsis
 }
 
 // Help returns the long help text including usage, description, and list of flags for the command
-func (b *Test) Help() string {
+func (c *Test) Help() string {
 	return testHelp
 }
 
 // Run runs the actual command with the given CLI instance and command-line arguments
-func (b *Test) Run(args []string) int {
-	b.ui.Output("test command run")
+func (c *Test) Run(args []string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := c.tester.Coverage(ctx)
+	if err != nil {
+		c.ui.Error(err.Error())
+		return 1
+	}
+
 	return 0
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -1,0 +1,145 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	atomicMode   = "atomic"
+	atomicHeader = "mode: atomic\n"
+
+	reportPath = "coverage"
+	coverFile  = "cover.out"
+	reportFile = "index.html"
+)
+
+type (
+	// Tester is the interface for test runner
+	Tester interface {
+		Coverage(context.Context) error
+	}
+
+	tester struct {
+		path string
+	}
+)
+
+// NewTester creates a new instance of test Tester
+func NewTester(path string) Tester {
+	return &tester{
+		path: path,
+	}
+}
+
+func (t *tester) getPackages(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "./...")
+	cmd.Dir = t.path
+	out, err := cmd.Output()
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%s. %s", e.Error(), string(e.Stderr))
+		}
+		return nil, err
+	}
+
+	pkgs := strings.Split(string(out), "\n")
+	pkgs = pkgs[:len(pkgs)-1]
+
+	return pkgs, nil
+}
+
+func (t *tester) testPackage(ctx context.Context, pkg, coverfile string) error {
+	// Open the singleton coverage file
+	cf, err := os.OpenFile(coverfile, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer cf.Close()
+
+	// Create a temporary file for collecting cover output of each package
+	tf, err := ioutil.TempFile("", "cover-*.out")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tf.Name())
+
+	// Run go test in cover mode
+	cmd := exec.CommandContext(ctx, "go", "test", "-covermode", atomicMode, "-coverprofile", tf.Name(), pkg)
+	cmd.Dir = t.path
+	_, err = cmd.Output()
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("%s. %s", e.Error(), string(e.Stderr))
+		}
+		return err
+	}
+
+	// Get the coverage data
+	cmd = exec.CommandContext(ctx, "tail", "-n", "+2", tf.Name())
+	cmd.Dir = t.path
+	out, err := cmd.Output()
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("%s. %s", e.Error(), string(e.Stderr))
+		}
+		return err
+	}
+
+	// Append the coverage data to the singleton coverage file
+	_, err = cf.WriteString(string(out))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *tester) Coverage(ctx context.Context) error {
+	coverpath := filepath.Join(t.path, reportPath)
+	coverfile := filepath.Join(coverpath, coverFile)
+	reportfile := filepath.Join(coverpath, reportFile)
+
+	// Remove any prior coverage report
+	err := os.RemoveAll(coverpath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Mkdir(coverpath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(coverfile, []byte(atomicHeader), 0644)
+	if err != nil {
+		return err
+	}
+
+	packages, err := t.getPackages(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, pkg := range packages {
+		err = t.testPackage(ctx, pkg, coverfile)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Generate the singleton html coverage report for all packages
+	cmd := exec.CommandContext(ctx, "go", "tool", "cover", "-html", coverfile, "-o", reportfile)
+	cmd.Dir = t.path
+	_, err = cmd.Output()
+	if e, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("%s. %s", e.Error(), string(e.Stderr))
+	}
+
+	return nil
+}

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -1,0 +1,127 @@
+package test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTester(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "CurrentPath",
+			path: "./",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := NewTester(tc.path)
+			assert.NotNil(t, tester)
+		})
+	}
+}
+
+func TestGetPackages(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		ctx              context.Context
+		expectedError    string
+		expectedPackages []string
+	}{
+		{
+			name:             "NoPackage",
+			path:             os.TempDir(),
+			ctx:              context.Background(),
+			expectedError:    "exit status 1",
+			expectedPackages: nil,
+		},
+		{
+			name:             "CurrentPath",
+			path:             "./",
+			ctx:              context.Background(),
+			expectedError:    "",
+			expectedPackages: []string{"github.com/moorara/cherry/internal/test"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := &tester{
+				path: tc.path,
+			}
+
+			packages, err := tester.getPackages(tc.ctx)
+
+			if tc.expectedError != "" {
+				assert.Contains(t, err.Error(), tc.expectedError)
+				assert.Nil(t, packages)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedPackages, packages)
+			}
+		})
+	}
+}
+
+func TestTestPackage(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		ctx           context.Context
+		pkg           string
+		coverfile     string
+		expectedError string
+	}{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := &tester{
+				path: tc.path,
+			}
+
+			err := tester.testPackage(tc.ctx, tc.pkg, tc.coverfile)
+
+			if tc.expectedError != "" {
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCoverage(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		ctx           context.Context
+		expectedError string
+	}{}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tester := &tester{
+				path: tc.path,
+			}
+
+			err := tester.Coverage(tc.ctx)
+
+			if tc.expectedError != "" {
+				assert.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Cleanup
+			os.RemoveAll(filepath.Join(tc.path, reportPath))
+		})
+	}
+}


### PR DESCRIPTION
Add `test` package for running `go test` and generate an aggregated coverage report for all packages.