### PR TITLE
Skip CI for next version commit

### DIFF
--- a/internal/v1/formula/release.go
+++ b/internal/v1/formula/release.go
@@ -169,7 +169,7 @@ func (f *formula) Release(ctx context.Context, level ReleaseLevel, comment strin
 		return err
 	}
 
-	commitMessage = fmt.Sprintf("Beginning %s", next.PreRelease())
+	commitMessage = fmt.Sprintf("Beginning %s [skip ci]", next.PreRelease())
 	err = f.Git.Commit(commitMessage, f.Spec.VersionFile)
 	if err != nil {
 		return err


### PR DESCRIPTION
When creating `Beginning ...` we need to add `[skip ci]`, so we wont trigger a build for that commit.