### PR TITLE
Fix push tag issue

### DIFF
--- a/internal/service/git.go
+++ b/internal/service/git.go
@@ -18,7 +18,8 @@ type (
 		GetHEAD() (*Commit, error)
 		Commit(message string, files ...string) error
 		Tag(tag string) error
-		Push(withTags bool) error
+		Push() error
+		PushTag(tag string) error
 		Pull() error
 	}
 
@@ -197,7 +198,7 @@ func (g *git) Tag(tag string) error {
 	return nil
 }
 
-func (g *git) Push(withTags bool) error {
+func (g *git) Push() error {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -210,18 +211,20 @@ func (g *git) Push(withTags bool) error {
 		return fmt.Errorf("%s: %s", err.Error(), stderr.String())
 	}
 
-	stdout.Reset()
-	stderr.Reset()
+	return nil
+}
 
-	if withTags {
-		// git push --tags
-		cmd := exec.Command("git", "push", "--tags")
-		cmd.Dir = g.workDir
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("%s: %s", err.Error(), stderr.String())
-		}
+func (g *git) PushTag(tag string) error {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	// git push
+	cmd := exec.Command("git", "push", "origin", tag)
+	cmd.Dir = g.workDir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %s", err.Error(), stderr.String())
 	}
 
 	return nil

--- a/internal/service/git_test.go
+++ b/internal/service/git_test.go
@@ -204,13 +204,11 @@ func TestGitPush(t *testing.T) {
 	tests := []struct {
 		name          string
 		workDir       string
-		withTags      bool
 		expectedError bool
 	}{
 		{
 			name:          "Error",
 			workDir:       os.TempDir(),
-			withTags:      true,
 			expectedError: true,
 		},
 	}
@@ -218,7 +216,36 @@ func TestGitPush(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			git := NewGit(tc.workDir)
-			err := git.Push(tc.withTags)
+			err := git.Push()
+
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGitPushTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		workDir       string
+		tag           string
+		expectedError bool
+	}{
+		{
+			name:          "Error",
+			workDir:       os.TempDir(),
+			tag:           "v0.1.0",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			git := NewGit(tc.workDir)
+			err := git.PushTag(tc.tag)
 
 			if tc.expectedError {
 				assert.Error(t, err)

--- a/internal/v1/formula/mock_test.go
+++ b/internal/v1/formula/mock_test.go
@@ -66,6 +66,8 @@ type (
 		TagMocks         []TagMock
 		PushCounter      int
 		PushMocks        []PushMock
+		PushTagCounter   int
+		PushTagMocks     []PushTagMock
 		PullMockCounter  int
 		PullMocks        []PullMock
 	}
@@ -102,8 +104,12 @@ type (
 	}
 
 	PushMock struct {
-		InWithTags bool
-		OutError   error
+		OutError error
+	}
+
+	PushTagMock struct {
+		InTag    string
+		OutError error
 	}
 
 	PullMock struct {
@@ -150,10 +156,16 @@ func (m *mockGit) Tag(tag string) error {
 	return mock.OutError
 }
 
-func (m *mockGit) Push(withTags bool) error {
+func (m *mockGit) Push() error {
 	mock := &m.PushMocks[m.PushCounter]
 	m.PushCounter++
-	mock.InWithTags = withTags
+	return mock.OutError
+}
+
+func (m *mockGit) PushTag(tag string) error {
+	mock := &m.PushTagMocks[m.PushTagCounter]
+	m.PushTagCounter++
+	mock.InTag = tag
 	return mock.OutError
 }
 

--- a/internal/v1/formula/release.go
+++ b/internal/v1/formula/release.go
@@ -163,12 +163,16 @@ func (f *formula) Release(ctx context.Context, level ReleaseLevel, comment strin
 	}()
 
 	f.Infof("⬆️  Pushing commit for release %s ...", release.Name)
-	err = f.git.Push(true)
+	err = f.git.Push()
 	if err != nil {
 		return err
 	}
 
-	// f.Printf("▶️  Preparing next version %s ...", next.PreRelease())
+	f.Infof("⬆️  Pushing tag for release %s ...", release.Name)
+	err = f.git.PushTag(current.GitTag())
+	if err != nil {
+		return err
+	}
 
 	err = f.vmanager.Update(next.PreRelease())
 	if err != nil {
@@ -182,7 +186,7 @@ func (f *formula) Release(ctx context.Context, level ReleaseLevel, comment strin
 	}
 
 	f.Infof("⬆️  Pushing commit for next version %s ...", next.PreRelease())
-	err = f.git.Push(false)
+	err = f.git.Push()
 	if err != nil {
 		return err
 	}

--- a/internal/v1/formula/release_test.go
+++ b/internal/v1/formula/release_test.go
@@ -1025,6 +1025,112 @@ func TestRelease(t *testing.T) {
 			expectedError: "git push error",
 		},
 		{
+			name: "GitPushTagFails",
+			formula: &formula{
+				githubToken: "github-token",
+				spec:        &spec.Spec{},
+				ui:          &mockUI{},
+				git: &mockGit{
+					GetRepoMocks: []GetRepoMock{
+						{
+							OutRepo: &service.Repo{
+								Owner: "moorara",
+								Name:  "cherry",
+							},
+						},
+					},
+					GetBranchMocks: []GetBranchMock{
+						{
+							OutBranch: &service.Branch{
+								Name: "master",
+							},
+						},
+					},
+					IsCleanMocks: []IsCleanMock{
+						{
+							OutResult: true,
+						},
+					},
+					PullMocks: []PullMock{
+						{
+							OutError: nil,
+						},
+					},
+					CommitMocks: []CommitMock{
+						{
+							OutError: nil,
+						},
+					},
+					TagMocks: []TagMock{
+						{
+							OutError: nil,
+						},
+					},
+					PushMocks: []PushMock{
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
+						{
+							OutError: errors.New("git push tag error"),
+						},
+					},
+				},
+				github: &mockGithub{
+					CreateReleaseMocks: []CreateReleaseMock{
+						{
+							OutRelease: &service.Release{
+								ID:         12345678,
+								Name:       "0.1.0",
+								TagName:    "v0.1.0",
+								Target:     "master",
+								Draft:      true,
+								Prerelease: false,
+								Body:       "",
+							},
+						},
+					},
+					BranchProtectionForAdminMocks: []BranchProtectionForAdminMock{
+						{
+							OutError: nil,
+						},
+						{
+							OutError: nil,
+						},
+					},
+				},
+				changelog: &mockChangelog{
+					FilenameMocks: []FilenameMock{
+						{
+							OutResult: "CHANGELOG.md",
+						},
+					},
+					GenerateMocks: []GenerateMock{
+						{
+							OutResult: "changelog text",
+						},
+					},
+				},
+				vmanager: &mockVersionManager{
+					ReadMocks: []ReadMock{
+						{
+							OutSemVer: service.SemVer{Major: 0, Minor: 1, Patch: 0},
+						},
+					},
+					UpdateMocks: []UpdateMock{
+						{
+							OutError: nil,
+						},
+					},
+				},
+			},
+			ctx:           context.Background(),
+			level:         PatchRelease,
+			comment:       "release description",
+			expectedError: "git push tag error",
+		},
+		{
 			name: "NextVersionUpdateFails",
 			formula: &formula{
 				githubToken: "github-token",
@@ -1067,6 +1173,11 @@ func TestRelease(t *testing.T) {
 						},
 					},
 					PushMocks: []PushMock{
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
 						{
 							OutError: nil,
 						},
@@ -1174,6 +1285,11 @@ func TestRelease(t *testing.T) {
 						},
 					},
 					PushMocks: []PushMock{
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
 						{
 							OutError: nil,
 						},
@@ -1288,6 +1404,11 @@ func TestRelease(t *testing.T) {
 							OutError: errors.New("git push error"),
 						},
 					},
+					PushTagMocks: []PushTagMock{
+						{
+							OutError: nil,
+						},
+					},
 				},
 				github: &mockGithub{
 					CreateReleaseMocks: []CreateReleaseMock{
@@ -1394,6 +1515,11 @@ func TestRelease(t *testing.T) {
 						{
 							OutError: nil,
 						},
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
 						{
 							OutError: nil,
 						},
@@ -1509,6 +1635,11 @@ func TestRelease(t *testing.T) {
 						{
 							OutError: nil,
 						},
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
 						{
 							OutError: nil,
 						},
@@ -1632,6 +1763,11 @@ func TestRelease(t *testing.T) {
 						{
 							OutError: nil,
 						},
+						{
+							OutError: nil,
+						},
+					},
+					PushTagMocks: []PushTagMock{
 						{
 							OutError: nil,
 						},


### PR DESCRIPTION
## Description

This PR fixes an issue regarding pushing git tags. Instead of pushing all tags through `git push --tags`, we will push only the release tag using `git push origin <tag>`.

### Checklist

#### General

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
