### PR TITLE
Fix issue with help command when github token is not set

### DIFF
--- a/cmd/command/release.go
+++ b/cmd/command/release.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/mitchellh/cli"
@@ -54,10 +53,6 @@ type release struct {
 
 // NewRelease creates a new release command.
 func NewRelease(ui cui.CUI, workDir, githubToken string, s spec.Spec) (cli.Command, error) {
-	if githubToken == "" {
-		return nil, errors.New("github token is not set")
-	}
-
 	return &release{
 		ui:     ui,
 		Spec:   s,

--- a/cmd/command/release_test.go
+++ b/cmd/command/release_test.go
@@ -20,11 +20,11 @@ func TestNewRelease(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:          "NoGitHubToken",
-			ui:            &mockCUI{},
-			workDir:       ".",
-			githubToken:   "",
-			expectedError: errors.New("github token is not set"),
+			name:        "NoGitHubToken",
+			ui:          &mockCUI{},
+			workDir:     ".",
+			githubToken: "",
+			spec:        spec.Spec{},
 		},
 		{
 			name:        "OK",


### PR DESCRIPTION
## Description

  - [x] Fixing the issue when running `cherry help` while the GitHub token is not set.

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
