### PR TITLE
Absorb the breaking change in github-changelog-generator

### DIFF
--- a/internal/action/release.go
+++ b/internal/action/release.go
@@ -118,10 +118,11 @@ func NewRelease(ui cui.CUI, workDir, githubToken string, s spec.Spec) Action {
 			},
 		},
 		step8: &step.ChangelogGenerate{
-			WorkDir:     workDir,
-			GitHubToken: githubToken,
-			Repo:        "TBD",
-			Tag:         "TBD",
+			WorkDir:       workDir,
+			GitHubToken:   githubToken,
+			GitHubUser:    "TBD",
+			GitHubProject: "TBD",
+			Tag:           "TBD",
 		},
 		step9: &step.GitAdd{
 			WorkDir: workDir,
@@ -294,7 +295,8 @@ func (r *release) Dry(ctx context.Context) error {
 	}
 
 	// Dry -- Create/Update change log
-	r.step8.Repo = r.step1.Result.Repo
+	r.step8.GitHubUser = r.step1.Result.Owner
+	r.step8.GitHubProject = r.step1.Result.Name
 	r.step8.Tag = curr.GitTag()
 	if err := r.step8.Dry(ctx); err != nil {
 		return err
@@ -470,7 +472,8 @@ func (r *release) Run(ctx context.Context) error {
 	r.ui.Outputf("➡️  Creating/Updating change log ...")
 
 	// Create/Update change log
-	r.step8.Repo = r.step1.Result.Repo
+	r.step8.GitHubUser = r.step1.Result.Owner
+	r.step8.GitHubProject = r.step1.Result.Name
 	r.step8.Tag = curr.GitTag()
 	if err := r.step8.Run(ctx); err != nil {
 		return err

--- a/internal/step/changelog.go
+++ b/internal/step/changelog.go
@@ -16,12 +16,13 @@ const changelogFilename = "CHANGELOG.md"
 
 // ChangelogGenerate runs `github_changelog_generator` Ruby gem!
 type ChangelogGenerate struct {
-	Mock        Step
-	WorkDir     string
-	GitHubToken string
-	Repo        string
-	Tag         string
-	Result      struct {
+	Mock          Step
+	WorkDir       string
+	GitHubToken   string
+	GitHubUser    string
+	GitHubProject string
+	Tag           string
+	Result        struct {
 		Filename  string
 		Changelog string
 	}
@@ -34,7 +35,15 @@ func (s *ChangelogGenerate) Dry(ctx context.Context) error {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "github_changelog_generator", "--version")
+
+	cmd := exec.CommandContext(ctx,
+		"github_changelog_generator",
+		"--token", s.GitHubToken,
+		"--user", s.GitHubUser,
+		"--project", s.GitHubProject,
+		"--output", "", // print the changelog to stdout
+	)
+
 	cmd.Dir = s.WorkDir
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -63,10 +72,11 @@ func (s *ChangelogGenerate) Run(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx,
 		"github_changelog_generator",
 		"--token", s.GitHubToken,
+		"--user", s.GitHubUser,
+		"--project", s.GitHubProject,
 		"--no-filter-by-milestone",
 		"--exclude-labels", "question,duplicate,invalid,wontfix",
 		"--future-release", s.Tag,
-		s.Repo,
 	)
 
 	cmd.Dir = s.WorkDir

--- a/internal/step/changelog_test.go
+++ b/internal/step/changelog_test.go
@@ -58,7 +58,8 @@ func TestChangelogGenerateDry(t *testing.T) {
 		name          string
 		workDir       string
 		gitHubToken   string
-		repo          string
+		gitHubUser    string
+		gitHubProject string
 		tag           string
 		expectedError string
 	}{}
@@ -66,10 +67,11 @@ func TestChangelogGenerateDry(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			step := ChangelogGenerate{
-				WorkDir:     tc.workDir,
-				GitHubToken: tc.gitHubToken,
-				Repo:        tc.repo,
-				Tag:         tc.tag,
+				WorkDir:       tc.workDir,
+				GitHubToken:   tc.gitHubToken,
+				GitHubUser:    tc.gitHubUser,
+				GitHubProject: tc.gitHubProject,
+				Tag:           tc.tag,
 			}
 
 			ctx := context.Background()
@@ -90,7 +92,8 @@ func TestChangelogGenerateRun(t *testing.T) {
 		name             string
 		workDir          string
 		gitHubToken      string
-		repo             string
+		gitHubUser       string
+		gitHubProject    string
 		tag              string
 		expectedError    string
 		expectedFilename string
@@ -99,10 +102,11 @@ func TestChangelogGenerateRun(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			step := ChangelogGenerate{
-				WorkDir:     tc.workDir,
-				GitHubToken: tc.gitHubToken,
-				Repo:        tc.repo,
-				Tag:         tc.tag,
+				WorkDir:       tc.workDir,
+				GitHubToken:   tc.gitHubToken,
+				GitHubUser:    tc.gitHubUser,
+				GitHubProject: tc.gitHubProject,
+				Tag:           tc.tag,
 			}
 
 			ctx := context.Background()
@@ -125,7 +129,8 @@ func TestChangelogGenerateRevert(t *testing.T) {
 		name          string
 		workDir       string
 		gitHubToken   string
-		repo          string
+		gitHubUser    string
+		gitHubProject string
 		tag           string
 		expectedError string
 	}{}
@@ -133,10 +138,11 @@ func TestChangelogGenerateRevert(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			step := ChangelogGenerate{
-				WorkDir:     tc.workDir,
-				GitHubToken: tc.gitHubToken,
-				Repo:        tc.repo,
-				Tag:         tc.tag,
+				WorkDir:       tc.workDir,
+				GitHubToken:   tc.gitHubToken,
+				GitHubUser:    tc.gitHubUser,
+				GitHubProject: tc.gitHubProject,
+				Tag:           tc.tag,
 			}
 
 			ctx := context.Background()

--- a/internal/step/github_test.go
+++ b/internal/step/github_test.go
@@ -27,7 +27,7 @@ func createMockHTTPServer(mocks ...mockHTTP) *httptest.Server {
 	for _, m := range mocks {
 		r.Methods(m.Method).Path(m.Path).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(m.StatusCode)
-			w.Write([]byte(m.ResponseBody))
+			_, _ = w.Write([]byte(m.ResponseBody))
 		})
 	}
 


### PR DESCRIPTION
## Description

Since `github_changelog_generator 1.15.0` there is a breaking change introduced that requires the GitHub username and projects be specified explicitly.

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
