### PR TITLE
Add new SSH URL schema

### DIFF
--- a/internal/step/git_test.go
+++ b/internal/step/git_test.go
@@ -20,8 +20,6 @@ func TestParseGitURL(t *testing.T) {
 		{
 			name:          "Empty",
 			output:        ``,
-			expectedOwner: "",
-			expectedName:  "",
 			expectedError: "failed to get git repository url",
 		},
 		{
@@ -30,49 +28,61 @@ func TestParseGitURL(t *testing.T) {
 			origin	moorara/cherry (fetch)
 			origin	moorara/cherry (push)
 			`,
-			expectedOwner: "",
-			expectedName:  "",
 			expectedError: "failed to get git repository name",
 		},
 		{
-			name: "HTTPSSchema",
-			output: `
-			origin	https://github.com/moorara/cherry (fetch)
-			origin	https://github.com/moorara/cherry (push)
-			`,
-			expectedOwner: "moorara",
-			expectedName:  "cherry",
-			expectedError: "",
-		},
-		{
-			name: "HTTPSSchemaWithGit",
-			output: `
-			origin	https://github.com/moorara/cherry.git (fetch)
-			origin	https://github.com/moorara/cherry.git (push)
-			`,
-			expectedOwner: "moorara",
-			expectedName:  "cherry",
-			expectedError: "",
-		},
-		{
-			name: "SSHSchema",
+			name: "SSH#1",
 			output: `
 			origin	git@github.com:moorara/cherry (fetch)
 			origin	git@github.com:moorara/cherry (push)
 			`,
 			expectedOwner: "moorara",
 			expectedName:  "cherry",
-			expectedError: "",
 		},
 		{
-			name: "SSHSchemaWithGit",
+			name: "SSH#2",
 			output: `
 			origin	git@github.com:moorara/cherry.git (fetch)
 			origin	git@github.com:moorara/cherry.git (push)
 			`,
 			expectedOwner: "moorara",
 			expectedName:  "cherry",
-			expectedError: "",
+		},
+		{
+			name: "HTTPS#1",
+			output: `
+			origin	https://github.com/moorara/cherry (fetch)
+			origin	https://github.com/moorara/cherry (push)
+			`,
+			expectedOwner: "moorara",
+			expectedName:  "cherry",
+		},
+		{
+			name: "HTTPS#2",
+			output: `
+			origin	https://github.com/moorara/cherry.git (fetch)
+			origin	https://github.com/moorara/cherry.git (push)
+			`,
+			expectedOwner: "moorara",
+			expectedName:  "cherry",
+		},
+		{
+			name: "CustomSSH#1",
+			output: `
+			origin	ssh://git@github.com/moorara/cherry (fetch)
+			origin	ssh://git@github.com/moorara/cherry (push)
+			`,
+			expectedOwner: "moorara",
+			expectedName:  "cherry",
+		},
+		{
+			name: "CustomSSH#2",
+			output: `
+			origin	ssh://git@github.com/moorara/cherry.git (fetch)
+			origin	ssh://git@github.com/moorara/cherry.git (push)
+			`,
+			expectedOwner: "moorara",
+			expectedName:  "cherry",
 		},
 	}
 


### PR DESCRIPTION
## Description

  - [x] Support a new scheme for ssh remote URL as `ssh://...`

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [x] Unit tests are provided for the new change
