### PR TITLE
Add empty test file for command package

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,3 @@
+package command
+
+// This file is required for test coverage to be reported zero for this package.


### PR DESCRIPTION
## Description

An empty test file for `internal/command` is required, so the test coverage will be reported zero for this package!

### Checklist

  - [x] PR title is clear and describes the work
  - [x] Commit messages are self-explanatory and summarize the change
  - [ ] Unit tests are provided for the new change
